### PR TITLE
Introduce Yjs collaborative sticky board

### DIFF
--- a/client/src/components/board/CollabStickyBoard.tsx
+++ b/client/src/components/board/CollabStickyBoard.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { useCollaboration } from '@/hooks/useCollaboration';
+import { NoteProvider } from './noteContext';
+import { StickyNoteShell } from '@/components/noteShell/StickyNoteShell';
+import { noteRegistry } from './noteRegistry';
+import type { NoteKind } from '@/types/notes';
+import type { StickyNoteData } from '@/types/notes';
+import { nanoid } from 'nanoid';
+
+interface BoardProps { spaceId?: string; }
+
+export const CollabStickyBoard: React.FC<BoardProps> = ({ spaceId = 'demo-space' }) => {
+  const { notes, addNote, updateNote, deleteNote, isConnected } = useCollaboration(spaceId);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [gridSnap, setGridSnap] = useState(true);
+
+  const handleCreate = useCallback((kind: NoteKind) => {
+    const newNote: StickyNoteData = {
+      id: nanoid(),
+      type: kind,
+      content: kind === 'checklist' ? { items: [] } : {},
+      position: { x: 80, y: 80, width: 250, height: 200, rotation: 0 },
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    addNote(newNote);
+    setSelectedId(newNote.id);
+  }, [addNote]);
+
+  const ctxValue = useMemo(() => ({
+    selectedId,
+    select: setSelectedId,
+    updateNote,
+    deleteNote,
+    gridSnap,
+  }), [selectedId, updateNote, deleteNote, gridSnap]);
+
+  return (
+    <NoteProvider value={ctxValue}>
+      <div className="relative w-full h-full pinboard-bg overflow-hidden">
+        <div className="absolute top-4 left-4 z-50 flex gap-2 pointer-events-auto">
+          {(['text','checklist','image','voice','drawing'] as NoteKind[]).map(k => (
+            <button
+              key={k}
+              onClick={() => handleCreate(k)}
+              className="px-3 py-1 rounded-md shadow-neu text-sm bg-white/80"
+            >
+              + {k}
+            </button>
+          ))}
+          <label className="ml-4 flex items-center gap-1 text-xs">
+            <input type="checkbox" checked={gridSnap} onChange={() => setGridSnap(!gridSnap)} />
+            Grid
+          </label>
+          <span className="text-xs ml-auto px-2 py-1 rounded bg-white/80">
+            {isConnected ? 'online' : 'offline'}
+          </span>
+        </div>
+        {notes.map(note => (
+          <StickyNoteShell key={note.id} note={note} />
+        ))}
+      </div>
+    </NoteProvider>
+  );
+};

--- a/client/src/components/journal/workspace.tsx
+++ b/client/src/components/journal/workspace.tsx
@@ -4,7 +4,7 @@ import { ContentBlock } from "./content-block";
 import { WeeklyCalendarView } from "./weekly-calendar-view";
 import { WeeklyCreativeView } from "./weekly-creative-view";
 import { MonthlyView } from "./monthly-view";
-import { StickyBoard } from "@/components/board/StickyBoard";
+import { CollabStickyBoard } from "@/components/board/CollabStickyBoard";
 import { useJournal } from "@/contexts/journal-context";
 import type { Position, ContentBlockType } from "@/types/journal";
 import { Plus } from "lucide-react";
@@ -88,8 +88,8 @@ export function JournalWorkspace() {
         <ContentBlock key={block.id} block={block} />
       ))}
 
-      {/* New StickyBoard Component */}
-      <StickyBoard spaceId={`workspace-${currentEntry.id}`} />
+      {/* Collaborative StickyBoard */}
+      <CollabStickyBoard spaceId={`workspace-${currentEntry.id}`} />
 
       {/* Floating Add Button */}
       <Button

--- a/client/src/components/noteShell/StickyNoteShell.tsx
+++ b/client/src/components/noteShell/StickyNoteShell.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   MouseEvent as ReactMouseEvent,
 } from "react";
-import { useNoteContext } from "@/contexts/journal-context";
+import { useNoteContext } from "@/components/board/noteContext";
 import { noteRegistry } from "@/components/board/noteRegistry";
 import { snapToGrid } from "@/utils/snapToGrid";
 import type { StickyNoteData } from "@/types/notes";

--- a/client/src/hooks/useCollaboration.ts
+++ b/client/src/hooks/useCollaboration.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState, useCallback } from 'react';
+import * as Y from 'yjs';
+import { WebsocketProvider } from 'y-websocket';
+import { IndexeddbPersistence } from 'y-indexeddb';
+import type { StickyNoteData } from '@/types/notes';
+
+export interface UserPresence {
+  id: string;
+}
+
+export const useCollaboration = (spaceId: string) => {
+  const [ydoc] = useState(() => new Y.Doc());
+  const [provider, setProvider] = useState<WebsocketProvider | null>(null);
+  const [notes, setNotes] = useState<StickyNoteData[]>([]);
+
+  useEffect(() => {
+    const wsProvider = new WebsocketProvider(`ws://${window.location.host}/collab/${spaceId}`, spaceId, ydoc);
+    const indexeddb = new IndexeddbPersistence(spaceId, ydoc);
+    setProvider(wsProvider);
+
+    const yNotes = ydoc.getArray<StickyNoteData>('notes');
+    const updateNotes = () => setNotes(yNotes.toArray());
+    yNotes.observe(updateNotes);
+    updateNotes();
+
+    return () => {
+      yNotes.unobserve(updateNotes);
+      wsProvider.destroy();
+      indexeddb.destroy();
+    };
+  }, [spaceId, ydoc]);
+
+  const addNote = useCallback((note: StickyNoteData) => {
+    ydoc.getArray<StickyNoteData>('notes').push([note]);
+  }, [ydoc]);
+
+  const updateNote = useCallback((id: string, updates: Partial<StickyNoteData>) => {
+    const yNotes = ydoc.getArray<StickyNoteData>('notes');
+    const arr = yNotes.toArray();
+    const index = arr.findIndex(n => n.id === id);
+    if (index >= 0) {
+      const updated = { ...arr[index], ...updates, updatedAt: new Date().toISOString() };
+      yNotes.delete(index, 1);
+      yNotes.insert(index, [updated]);
+    }
+  }, [ydoc]);
+
+  const deleteNote = useCallback((id: string) => {
+    const yNotes = ydoc.getArray<StickyNoteData>('notes');
+    const arr = yNotes.toArray();
+    const index = arr.findIndex(n => n.id === id);
+    if (index >= 0) {
+      yNotes.delete(index, 1);
+    }
+  }, [ydoc]);
+
+  const isConnected = provider?.wsconnected ?? false;
+
+  return { notes, addNote, updateNote, deleteNote, isConnected };
+};

--- a/client/src/mappers/blockToNote.ts
+++ b/client/src/mappers/blockToNote.ts
@@ -3,7 +3,7 @@ import type { ContentBlockData } from "@/types/journal";
 // Define the new note data structure for the shell system
 export interface StickyNoteData {
   id: string;
-  kind: 'text' | 'checklist' | 'image' | 'voice' | 'drawing';
+  type: 'text' | 'checklist' | 'image' | 'voice' | 'drawing';
   content: any;
   position: {
     x: number;
@@ -16,8 +16,8 @@ export interface StickyNoteData {
   updatedAt: string;
 }
 
-// Map ContentBlockType to note kind
-const typeToKind = (type: ContentBlockData['type']): StickyNoteData['kind'] => {
+// Map ContentBlockType to note type
+const blockTypeToNoteType = (type: ContentBlockData['type']): StickyNoteData['type'] => {
   switch (type) {
     case 'sticky_note':
     case 'text':
@@ -39,7 +39,7 @@ const typeToKind = (type: ContentBlockData['type']): StickyNoteData['kind'] => {
 export const blockToNote = (block: ContentBlockData): StickyNoteData => {
   return {
     id: block.id,
-    kind: typeToKind(block.type),
+    type: blockTypeToNoteType(block.type),
     content: block.content,
     position: block.position,
     createdAt: block.createdAt,

--- a/client/src/mappers/noteToBlockPatch.ts
+++ b/client/src/mappers/noteToBlockPatch.ts
@@ -1,5 +1,5 @@
 import { StickyNoteData } from "@/types/notes";
-import { ContentBlockData, Position } from "@/types/journal";
+import { ContentBlockData, Position, ContentBlockType } from "@/types/journal";
 
 /**
  * Converts a StickyNote update back to a ContentBlock patch
@@ -55,8 +55,8 @@ export const noteToBlock = (
 /**
  * Maps note types to legacy content block types
  */
-function mapNoteTypeToBlockType(noteType: string): string {
-  const typeMap: Record<string, string> = {
+function mapNoteTypeToBlockType(noteType: string): ContentBlockType {
+  const typeMap: Record<string, ContentBlockType> = {
     text: "text",
     checklist: "checklist",
     image: "photo",

--- a/client/src/types/notes.ts
+++ b/client/src/types/notes.ts
@@ -41,3 +41,18 @@ export type NoteContent =
 
 // Note kinds
 export type NoteKind = 'text' | 'checklist' | 'image' | 'voice' | 'drawing';
+
+export interface StickyNoteData {
+  id: string;
+  type: NoteKind;
+  content: any;
+  position: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    rotation: number;
+  };
+  createdAt: string;
+  updatedAt: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,9 @@
         "vaul": "^1.1.2",
         "wouter": "^3.3.5",
         "ws": "^8.18.0",
+        "y-indexeddb": "^9.0.12",
+        "y-websocket": "^3.0.0",
+        "yjs": "^13.6.27",
         "zod": "^3.24.2",
         "zod-validation-error": "^3.4.0"
       },
@@ -5851,6 +5854,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -5914,6 +5927,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.109",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.109.tgz",
+      "integrity": "sha512-jP0gbnyW0kwlx1Atc4dcHkBbrVAkdHjuyHxtClUPYla7qCmwIif1qZ6vQeJdR5FrOVdn26HvQT0ko01rgW7/Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lightningcss": {
@@ -9391,6 +9425,67 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y-indexeddb": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
+      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/y-websocket": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-3.0.0.tgz",
+      "integrity": "sha512-mUHy7AzkOZ834T/7piqtlA8Yk6AchqKqcrCXjKW8J1w2lPtRDjz8W5/CvXz9higKAHgKRKqpI3T33YkRFLkPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.102",
+        "y-protocols": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.5.6"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -9408,6 +9503,23 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.27",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
+      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     "vaul": "^1.1.2",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
+    "y-indexeddb": "^9.0.12",
+    "y-websocket": "^3.0.0",
+    "yjs": "^13.6.27",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0"
   },

--- a/server/collabServer.ts
+++ b/server/collabServer.ts
@@ -1,0 +1,48 @@
+import { Server } from 'http';
+import { WebSocketServer, WebSocket } from 'ws';
+import * as Y from 'yjs';
+
+interface DocWithClients extends Y.Doc {
+  clients: Set<WebSocket>;
+}
+
+const docs = new Map<string, DocWithClients>();
+
+function getDoc(name: string): DocWithClients {
+  let doc = docs.get(name);
+  if (!doc) {
+    doc = new Y.Doc() as DocWithClients;
+    doc.clients = new Set();
+    docs.set(name, doc);
+  }
+  return doc;
+}
+
+export function attachCollaboration(server: Server) {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (req, socket, head) => {
+    const url = new URL(req.url || '', `http://${req.headers.host}`);
+    if (!url.pathname?.startsWith('/collab/')) return;
+    wss.handleUpgrade(req, socket, head, ws => {
+      const space = url.pathname!.slice('/collab/'.length);
+      const doc = getDoc(space);
+      doc.clients.add(ws);
+      ws.send(Y.encodeStateAsUpdate(doc));
+
+      ws.on('message', msg => {
+        const update = new Uint8Array(msg as Buffer);
+        Y.applyUpdate(doc, update);
+        doc.clients.forEach(client => {
+          if (client !== ws && client.readyState === WebSocket.OPEN) {
+            client.send(update);
+          }
+        });
+      });
+
+      ws.on('close', () => {
+        doc.clients.delete(ws);
+      });
+    });
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
+import { attachCollaboration } from "./collabServer";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
@@ -38,6 +39,7 @@ app.use((req, res, next) => {
 
 (async () => {
   const server = await registerRoutes(app);
+  attachCollaboration(server);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;


### PR DESCRIPTION
## Summary
- add real-time collaboration server using Yjs and websockets
- new `useCollaboration` hook and `CollabStickyBoard` component
- wire collaborative board into journal workspace
- move note context import for shells
- update note types and mappers for `type` field
- add Yjs packages to dependencies

## Testing
- `npm run check` *(fails: TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_686f49b2f8988320ad2a56040657ff64