### PR TITLE
Implement friend calendar event deduplication and visibility refresh

### DIFF
--- a/client/src/services/__tests__/friend-calendar.service.test.ts
+++ b/client/src/services/__tests__/friend-calendar.service.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { duplicateEventResolver } from '@/services/duplicate-event-resolver.service';
+import type { CalendarEvent, FriendCalendarEvent } from '@/types/calendar';
+import { FriendCalendarServiceImpl } from '@/services/friend-calendar.service';
+
+// Helper to construct base dates
+const now = new Date();
+const in1h = new Date(now.getTime() + 60 * 60 * 1000);
+
+describe('Friend calendar: dedupe and background refresh', () => {
+  beforeEach(() => {
+    // Ensure document.hidden is writable for this test environment
+    try {
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+    } catch {
+      // ignore if environment does not support redefining
+    }
+  });
+
+  it('resolves duplicates across friend and external sources consistently (external wins by priority)', () => {
+    // ical event (external) with higher or equal sequence than friend
+    const icalEvent: CalendarEvent = {
+      id: 'ical-feed:evt-1',
+      title: 'Brunch',
+      description: 'with friends',
+      startTime: now,
+      endTime: in1h,
+      timezone: 'UTC',
+      isAllDay: false,
+      color: '#3B82F6',
+      location: 'Cafe',
+      attendees: ['alice@example.com'],
+      feedId: 'ical-feed',
+      feedName: 'Alice iCal',
+      externalId: 'evt-1',
+      sequence: 5, // higher
+      isRecurring: false,
+      source: 'ical',
+      lastModified: now,
+    };
+
+    const friendEvent: FriendCalendarEvent = {
+      id: 'friend-123:evt-1',
+      title: 'Brunch',
+      description: 'with friends',
+      startTime: now,
+      endTime: in1h,
+      timezone: 'UTC',
+      isAllDay: false,
+      color: '#10B981',
+      location: 'Cafe',
+      attendees: ['alice@example.com'],
+      feedId: 'friend-123',
+      feedName: "Alice's Calendar",
+      externalId: 'evt-1',
+      sequence: 2, // lower
+      isRecurring: false,
+      source: 'friend',
+      lastModified: now,
+      friendUserId: '123',
+      friendUsername: 'alice',
+      isFromFriend: true,
+      sourceId: '123',
+      canonicalEventId: 'evt-1',
+      originalEventId: 'evt-1',
+    };
+
+    const result = duplicateEventResolver.resolveEvents([icalEvent, friendEvent]);
+    expect(result.canonicalEvents.size).toBe(1);
+    const canonical = Array.from(result.canonicalEvents.values())[0];
+    // External source should win here
+    expect(canonical.source).toBe('ical');
+    expect('friendUserId' in (canonical as any)).toBe(false);
+    // Canonical ID includes feed scope of the primary item
+    expect(canonical.id.startsWith('canonical:evt-1:ical-feed')).toBe(true);
+  });
+
+  it('preserves friend metadata on canonical events when friend has higher sequence', () => {
+    const icalEvent: CalendarEvent = {
+      id: 'ical-feed:evt-2',
+      title: 'Gym',
+      description: 'leg day',
+      startTime: now,
+      endTime: in1h,
+      timezone: 'UTC',
+      isAllDay: false,
+      color: '#3B82F6',
+      location: 'Gym',
+      attendees: [],
+      feedId: 'ical-feed',
+      feedName: 'Alice iCal',
+      externalId: 'evt-2',
+      sequence: 1, // lower
+      isRecurring: false,
+      source: 'ical',
+      lastModified: now,
+    };
+
+    const friendEvent: FriendCalendarEvent = {
+      id: 'friend-123:evt-2',
+      title: 'Gym',
+      description: 'leg day',
+      startTime: now,
+      endTime: in1h,
+      timezone: 'UTC',
+      isAllDay: false,
+      color: '#10B981',
+      location: 'Gym',
+      attendees: [],
+      feedId: 'friend-123',
+      feedName: "Alice's Calendar",
+      externalId: 'evt-2',
+      sequence: 9, // higher
+      isRecurring: false,
+      source: 'friend',
+      lastModified: now,
+      friendUserId: '123',
+      friendUsername: 'alice',
+      isFromFriend: true,
+      sourceId: '123',
+      canonicalEventId: 'evt-2',
+      originalEventId: 'evt-2',
+    };
+
+    const result = duplicateEventResolver.resolveEvents([icalEvent, friendEvent]);
+    expect(result.canonicalEvents.size).toBe(1);
+    const canonical = Array.from(result.canonicalEvents.values())[0] as FriendCalendarEvent;
+    // Friend should win here
+    expect(canonical.source).toBe('friend');
+    expect(canonical.friendUserId).toBe('123');
+    expect(canonical.friendUsername).toBe('alice');
+    // Resolver adds canonical id for friend events
+    expect((canonical as FriendCalendarEvent).canonicalEventId).toBeDefined();
+  });
+
+  it('friend service uses deterministic color mapping and preserves friend metadata on canonical events', () => {
+    const svc = new FriendCalendarServiceImpl();
+    const friend = {
+      id: 'friend-xyz',
+      username: 'bob',
+      firstName: 'Bob',
+      lastName: 'Builder',
+    } as any;
+
+    // Establish feed color assignment
+    const feed = svc.createFriendFeed(friend);
+
+    const evA: FriendCalendarEvent = {
+      id: 'friend-xyz:evt-10',
+      title: 'Coffee',
+      description: '',
+      startTime: now,
+      endTime: in1h,
+      isAllDay: false,
+      color: '#000000',
+      location: undefined,
+      attendees: [],
+      feedId: `friend-${friend.id}`,
+      feedName: `${friend.firstName}'s Calendar`,
+      externalId: 'evt-10',
+      sequence: 1,
+      isRecurring: false,
+      source: 'friend',
+      lastModified: now,
+      friendUserId: friend.id,
+      friendUsername: friend.username,
+      isFromFriend: true,
+      sourceId: friend.id,
+      canonicalEventId: 'evt-10',
+      originalEventId: 'evt-10',
+    };
+
+    const evB: FriendCalendarEvent = {
+      ...evA,
+      id: 'friend-xyz:evt-10-dup',
+      sequence: 2, // newer version of same event
+    };
+
+    // Call the private method via any-cast for unit testing
+    const resolved = (svc as any).resolveAndColorizeFriendEvents(friend, [evA, evB]) as FriendCalendarEvent[];
+    expect(resolved.length).toBe(1);
+    const only = resolved[0];
+
+    // Color should match feed color (deterministic per friend via palette manager)
+    expect(only.color).toBe(feed.color);
+
+    // Ensure friend metadata is present on canonical event
+    expect(only.source).toBe('friend');
+    expect(only.friendUserId).toBe(friend.id);
+    expect(only.friendUsername).toBe(friend.username);
+    expect(only.isFromFriend).toBe(true);
+  });
+
+  it('background visibility refresh is rate-limited (handler invoked once within window)', () => {
+    const svc = new FriendCalendarServiceImpl();
+
+    // Spy on the internal refresh method to ensure rate limit gates calls
+    const spy = vi.fn();
+    (svc as any).handleVisibilityRefresh = spy;
+
+    // Ensure page is visible
+    try {
+      Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+    } catch {
+      // ignore
+    }
+
+    // Dispatch two visibility events quickly
+    document.dispatchEvent(new Event('visibilitychange'));
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    // Rate limit window is 5 minutes; consecutive dispatches should trigger only once
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/services/__tests__/friend-calendar.service.test.ts
+++ b/client/src/services/__tests__/friend-calendar.service.test.ts
@@ -183,6 +183,9 @@ describe('Friend calendar: dedupe and background refresh', () => {
 
     // Color should match feed color (deterministic per friend via palette manager)
     expect(only.color).toBe(feed.color);
+    // Pattern should be assigned for accessibility (from ColorAssignment)
+    expect(only.pattern).toBeDefined();
+    expect(['plain','stripe','dot']).toContain(only.pattern as any);
 
     // Ensure friend metadata is present on canonical event
     expect(only.source).toBe('friend');
@@ -211,5 +214,15 @@ describe('Friend calendar: dedupe and background refresh', () => {
 
     // Rate limit window is 5 minutes; consecutive dispatches should trigger only once
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroy() removes visibilitychange listener to avoid leaks', () => {
+    const svc = new FriendCalendarServiceImpl();
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    svc.destroy();
+
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    removeSpy.mockRestore();
   });
 });

--- a/client/src/services/calendar-feed.service.ts
+++ b/client/src/services/calendar-feed.service.ts
@@ -631,6 +631,11 @@ export class CalendarFeedServiceImpl implements CalendarFeedService {
     }
   }
 
+  // Public method to set visibility change handler (for factory function)
+  setVisibilityChangeHandler(handler: (() => void) | null): void {
+    this.visibilityChangeHandler = handler;
+  }
+
   // Private helper methods
   private async fetchEventsFromSource(
     feed: CalendarFeed,
@@ -972,7 +977,7 @@ export function createCalendarFeedService(): CalendarFeedServiceImpl {
   };
 
   // Store handler reference for cleanup and add listener
-  (feedService as any).visibilityChangeHandler = onVisibilityChange;
+  feedService.setVisibilityChangeHandler(onVisibilityChange);
   document.addEventListener('visibilitychange', onVisibilityChange);
 
   return feedService;

--- a/client/src/services/friend-calendar.service.ts
+++ b/client/src/services/friend-calendar.service.ts
@@ -160,6 +160,15 @@ export class FriendCalendarServiceImpl implements FriendCalendarService {
     const feedId = `friend-${friend.id}`;
 
     const enrichEvent = (ev: CalendarEvent): FriendCalendarEvent => {
+      // Use discriminated union type checking instead of unsafe casting
+      const originalEventId = ev.source === 'friend' 
+        ? ev.originalEventId || ev.externalId
+        : ev.externalId;
+      
+      const canonicalEventId = ev.source === 'friend' 
+        ? ev.canonicalEventId || `canonical:${ev.externalId}:${feedId}`
+        : `canonical:${ev.externalId}:${feedId}`;
+
       const merged: FriendCalendarEvent = {
         ...ev,
         source: 'friend' as const,
@@ -171,10 +180,9 @@ export class FriendCalendarServiceImpl implements FriendCalendarService {
         feedName: `${friend.firstName || friend.lastName || 'Friend'}'s Calendar`,
         color: assignment.color,
         pattern: assignment.pattern,
-        // Ensure originalEventId is always present, using externalId as fallback
-        originalEventId: (ev as FriendCalendarEvent).originalEventId || ev.externalId,
-        // Ensure canonicalEventId is always present
-        canonicalEventId: (ev as FriendCalendarEvent).canonicalEventId || `canonical:${ev.externalId}:${feedId}`,
+        // Safely access properties using discriminated union checking
+        originalEventId,
+        canonicalEventId,
       };
 
       return merged;

--- a/client/src/services/friend-calendar.service.ts
+++ b/client/src/services/friend-calendar.service.ts
@@ -2,7 +2,7 @@
  * Friend calendar service for handling friend calendar synchronization
  */
 
-import type { FriendCalendarEvent, CalendarFeed, DateRange } from '@/types/calendar';
+import type { FriendCalendarEvent, CalendarFeed, DateRange, CalendarEvent } from '@/types/calendar';
 import type { Friend } from '@/types/journal';
 import { generateFriendColor as sharedGenerateFriendColor } from '@/utils/colorUtils/colorUtils';
 import { timezoneService } from './timezone.service';
@@ -85,7 +85,9 @@ export class FriendCalendarServiceImpl implements FriendCalendarService {
   constructor() {
     // Rate-limited background refresh on tab visibility regain (mirrors feeds)
     this.visibilityChangeHandler = (event: Event) => {
-      if (typeof document === 'undefined' || (document as any).hidden) return;
+      // document.hidden is part of the Page Visibility API (DOM lib). If TS DOM types are unavailable, ensure "dom" is in tsconfig lib.
+      // @ts-ignore Ensure DOM typings include Page Visibility API
+      if (typeof document === 'undefined' || document.hidden) return;
       const now = Date.now();
       if (now - this.lastVisibilityRefresh < this.VISIBILITY_REFRESH_MIN_MS) return;
       this.lastVisibilityRefresh = now;
@@ -159,7 +161,7 @@ export class FriendCalendarServiceImpl implements FriendCalendarService {
     const assignment = this.getFriendColorAssignment(friend.id);
     const feedId = `friend-${friend.id}`;
 
-    const enrichEvent = (ev: any): FriendCalendarEvent => {
+    const enrichEvent = (ev: CalendarEvent): FriendCalendarEvent => {
       const merged: FriendCalendarEvent = {
         ...ev,
         source: 'friend' as const,

--- a/client/src/services/friend-calendar.service.ts
+++ b/client/src/services/friend-calendar.service.ts
@@ -85,8 +85,6 @@ export class FriendCalendarServiceImpl implements FriendCalendarService {
   constructor() {
     // Rate-limited background refresh on tab visibility regain (mirrors feeds)
     this.visibilityChangeHandler = (event: Event) => {
-      // document.hidden is part of the Page Visibility API (DOM lib). If TS DOM types are unavailable, ensure "dom" is in tsconfig lib.
-      // @ts-ignore Ensure DOM typings include Page Visibility API
       if (typeof document === 'undefined' || document.hidden) return;
       const now = Date.now();
       if (now - this.lastVisibilityRefresh < this.VISIBILITY_REFRESH_MIN_MS) return;
@@ -173,11 +171,12 @@ export class FriendCalendarServiceImpl implements FriendCalendarService {
         feedName: `${friend.firstName || friend.lastName || 'Friend'}'s Calendar`,
         color: assignment.color,
         pattern: assignment.pattern,
-      } as FriendCalendarEvent;
+        // Ensure originalEventId is always present, using externalId as fallback
+        originalEventId: (ev as FriendCalendarEvent).originalEventId || ev.externalId,
+        // Ensure canonicalEventId is always present
+        canonicalEventId: (ev as FriendCalendarEvent).canonicalEventId || `canonical:${ev.externalId}:${feedId}`,
+      };
 
-      if (!merged.canonicalEventId) {
-        merged.canonicalEventId = `canonical:${merged.externalId}:${feedId}`;
-      }
       return merged;
     };
 


### PR DESCRIPTION
- Introduced a new method to resolve and colorize friend events, ensuring consistent deduplication with external sources.
- Added a rate-limited visibility refresh mechanism to clear stale friend windows based on a defined TTL.
- Enhanced friend color assignment logic using a color palette manager for deterministic color mapping.
- Added unit tests to validate deduplication and background refresh functionality.